### PR TITLE
Add year and position columns to aggregated list

### DIFF
--- a/aggregate_scores.py
+++ b/aggregate_scores.py
@@ -11,7 +11,7 @@ for fname in os.listdir(DATA_FOLDER):
         path = os.path.join(DATA_FOLDER, fname)
         df = pd.read_csv(path)
         # Keep only the columns we need and track which file the row came from
-        df = df[['Title', 'Score']].copy()
+        df = df[['Title', 'Score', 'ReleaseDate']].copy()
         df['SourceFile'] = fname
         frames.append(df)
 
@@ -23,10 +23,23 @@ all_games = pd.concat(frames, ignore_index=True)
 # Aggregate total score and number of lists each game appears in
 agg = (
     all_games.groupby('Title')
-    .agg(TotalScore=('Score', 'sum'), ListsAppeared=('SourceFile', 'nunique'))
+    .agg(
+        TotalScore=('Score', 'sum'),
+        ListsAppeared=('SourceFile', 'nunique'),
+        ReleaseYear=('ReleaseDate', lambda x: pd.to_datetime(x.iloc[0]).year),
+    )
     .sort_values(by='TotalScore', ascending=False)
     .reset_index()
 )
+
+# Append the release year to the title, e.g. "Mario (2001)"
+agg['Title'] = agg['Title'] + " (" + agg['ReleaseYear'].astype(str) + ")"
+
+# Add a position column starting at 1
+agg.insert(0, 'Position', range(1, len(agg) + 1))
+
+# We no longer need the ReleaseYear column in the CSV
+agg = agg.drop(columns=['ReleaseYear'])
 
 output_path = os.path.join(DATA_FOLDER, 'aggregated-list.csv')
 agg.to_csv(output_path, index=False)


### PR DESCRIPTION
## Summary
- keep ReleaseDate when loading CSV files
- output aggregated CSV with release year appended to title
- add a Position column starting at 1

## Testing
- `python3 -m py_compile aggregate_scores.py`
- `python3 aggregate_scores.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6845f4869c0c8321a368981eaf2a4bca