### PR TITLE
Add example scraper for walking simulator list

### DIFF
--- a/best_walking_simulator_games_of_all_time/GamerantScraper.cs
+++ b/best_walking_simulator_games_of_all_time/GamerantScraper.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using HtmlAgilityPack;
+
+public class GamerantScraper
+{
+    private const string Url = "https://gamerant.com/best-walking-simulators/";
+
+    public static List<(int Position, string Title)> FetchGames(string url = Url)
+    {
+        var handler = new HttpClientHandler
+        {
+            AutomaticDecompression = System.Net.DecompressionMethods.GZip | System.Net.DecompressionMethods.Deflate
+        };
+        using var client = new HttpClient(handler);
+        client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0");
+        var html = client.GetStringAsync(url).Result;
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var entries = new List<(int, string)>();
+        foreach (var heading in doc.DocumentNode.SelectNodes("//h2|//h3") ?? new HtmlNodeCollection(null))
+        {
+            var text = heading.InnerText.Trim();
+            var match = Regex.Match(text, @"^(\d+)\.?\s*(.*)");
+            if (!match.Success)
+                continue;
+            if (!int.TryParse(match.Groups[1].Value, out int pos))
+                continue;
+            var titlePart = match.Groups[2].Value.Trim();
+            var title = Regex.Replace(titlePart, @"\(\d{4}\)$", string.Empty).Trim();
+            entries.Add((pos, title));
+        }
+
+        if (entries.Count == 0)
+            throw new Exception("Could not find any game entries in the page");
+
+        entries.Sort((a, b) => a.Item1.CompareTo(b.Item1));
+        return entries;
+    }
+
+    public static void WriteCsv(List<(int Position, string Title)> entries)
+    {
+        var now = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss");
+        var outPath = $"gamerant - {now}.csv";
+        var total = entries.Count;
+
+        using var writer = new StreamWriter(outPath, false, System.Text.Encoding.UTF8);
+        writer.WriteLine("Position,Title,ReleaseDate,ExternalId,Score,GameId,CoverImageId");
+        foreach (var (position, title) in entries)
+        {
+            var score = total - position + 1;
+            writer.WriteLine($"{position},{Escape(title)},,,{score},,");
+        }
+        Console.WriteLine($"Written {outPath} with {total} entries");
+    }
+
+    private static string Escape(string value)
+    {
+        if (value.Contains(",") || value.Contains("\"") || value.Contains("\n"))
+            return "\"" + value.Replace("\"", "\"\"") + "\"";
+        return value;
+    }
+
+    public static void Main(string[] args)
+    {
+        var entries = FetchGames();
+        WriteCsv(entries);
+    }
+}

--- a/best_walking_simulator_games_of_all_time/scrape_gamerant_walking_sims.py
+++ b/best_walking_simulator_games_of_all_time/scrape_gamerant_walking_sims.py
@@ -1,0 +1,58 @@
+import csv
+import re
+from datetime import datetime
+import requests
+from bs4 import BeautifulSoup
+
+URL = 'https://gamerant.com/best-walking-simulators/'
+
+
+def fetch_games(url=URL):
+    response = requests.get(url, headers={'User-Agent': 'Mozilla/5.0'})
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, 'html.parser')
+    entries = []
+    for heading in soup.find_all(['h2', 'h3']):
+        text = heading.get_text(separator=' ', strip=True)
+        m = re.match(r'(\d+)\.?\s*(.*)', text)
+        if not m:
+            continue
+        pos = int(m.group(1))
+        title_part = m.group(2)
+        # Remove year in parentheses if present
+        title = re.sub(r'\(\d{4}\)$', '', title_part).strip()
+        entries.append((pos, title))
+    if not entries:
+        raise ValueError('Could not find any game entries in the page')
+    entries.sort(key=lambda x: x[0])
+    return entries
+
+
+def write_csv(entries):
+    now = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+    out_path = f'gamerant - {now}.csv'
+    total = len(entries)
+    with open(out_path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            'Position',
+            'Title',
+            'ReleaseDate',
+            'ExternalId',
+            'Score',
+            'GameId',
+            'CoverImageId'
+        ])
+        for position, title in entries:
+            score = total - position + 1
+            writer.writerow([position, title, '', '', score, '', ''])
+    print(f'Written {out_path} with {total} entries')
+
+
+def main():
+    entries = fetch_games()
+    write_csv(entries)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a simple Python script to scrape Gamerant's walking simulator list

## Testing
- `python scrape_gamerant_walking_sims.py` *(fails: No module named 'requests')*
- `pip install requests beautifulsoup4` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684711a3adac8321b2ea78a65b53cb4b